### PR TITLE
Feature/Extend session. APP-81

### DIFF
--- a/lib/src/api/sentinel_api.dart
+++ b/lib/src/api/sentinel_api.dart
@@ -141,6 +141,11 @@ abstract class SentinelApi {
   @Headers({'Content-Type': 'application/json'})
   Future<Session?> getSession(@Path() String sessionID);
 
+  /// Extends a session
+  @PATCH('/auth/sessions/extend')
+  @Headers({'Content-Type': 'application/json'})
+  Future<bool> extendSession();
+
   /// Deletes all sessions for the user
   @DELETE('/auth/sessions/')
   @Headers({'Content-Type': 'application/json'})

--- a/lib/src/api/sentinel_api.g.dart
+++ b/lib/src/api/sentinel_api.g.dart
@@ -1483,6 +1483,41 @@ class _SentinelApi implements SentinelApi {
   }
 
   @override
+  Future<bool> extendSession() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{r'Content-Type': 'application/json'};
+    _headers.removeWhere((k, v) => v == null);
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<bool>(Options(
+      method: 'PATCH',
+      headers: _headers,
+      extra: _extra,
+      contentType: 'application/json',
+    )
+        .compose(
+          _dio.options,
+          '/auth/sessions/extend',
+          queryParameters: queryParameters,
+          data: _data,
+        )
+        .copyWith(
+            baseUrl: _combineBaseUrls(
+          _dio.options.baseUrl,
+          baseUrl,
+        )));
+    final _result = await _dio.fetch<bool>(_options);
+    late bool _value;
+    try {
+      _value = _result.data!;
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
   Future<bool> deleteAllSessions() async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};


### PR DESCRIPTION
This pull request introduces a new feature to extend user sessions in the `SentinelApi`. The most important change include the addition of a new method in the `SentinelApi` abstract class.

### New Feature: Extend User Sessions

* [`lib/src/api/sentinel_api.dart`](diffhunk://#diff-f844dac204ed8b783d4367f04983c9bff99aaaa8d2d47816abebe3f2f15d7774R144-R148): Added a new method `extendSession` to the `SentinelApi` abstract class to allow extending user sessions.