### PR TITLE
fix: changed all freezed class from classic to abstract. Part of APP-237

### DIFF
--- a/lib/src/models/device.dart
+++ b/lib/src/models/device.dart
@@ -33,32 +33,20 @@ enum DeviceType {
 /// identifier, name, type, associated user ID, creation time, and the
 /// last time it was used for sign-in.
 @freezed
-@JsonSerializable()
-class Device with _$Device {
+abstract class Device with _$Device {
   /// Creates a new instance of [Device] with the specified parameters.
-  const Device({
-    required this.id,
-    required this.deviceID,
-    required this.name,
-    required this.type,
-    required this.userID,
-    required this.createdAt,
-    required this.lastSignedInAt,
-  });
+  const factory Device({
+    required String id,
+    required String deviceID,
+    required String name,
+    required DeviceType type,
+    required String userID,
+    required DateTime createdAt,
+    required DateTime lastSignedInAt,
+  }) = _Device;
 
   /// Used to serialize [Device] object from JSON.
   factory Device.fromJson(Map<String, Object?> json) => _$DeviceFromJson(json);
-
-  /// Used to serialize [Device] object to JSON.
-  Map<String, Object?> toJson() => _$DeviceToJson(this);
-
-  final String id;
-  final String deviceID;
-  final String name;
-  final DeviceType type;
-  final String userID;
-  final DateTime createdAt;
-  final DateTime lastSignedInAt;
 }
 
 /// Converter for [Device] enumeration.

--- a/lib/src/models/device.freezed.dart
+++ b/lib/src/models/device.freezed.dart
@@ -30,6 +30,9 @@ mixin _$Device {
   $DeviceCopyWith<Device> get copyWith =>
       _$DeviceCopyWithImpl<Device>(this as Device, _$identity);
 
+  /// Serializes this Device to a JSON map.
+  Map<String, dynamic> toJson();
+
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
@@ -93,7 +96,147 @@ class _$DeviceCopyWithImpl<$Res> implements $DeviceCopyWith<$Res> {
     Object? createdAt = null,
     Object? lastSignedInAt = null,
   }) {
-    return _then(Device(
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      deviceID: null == deviceID
+          ? _self.deviceID
+          : deviceID // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      type: null == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as DeviceType,
+      userID: null == userID
+          ? _self.userID
+          : userID // ignore: cast_nullable_to_non_nullable
+              as String,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      lastSignedInAt: null == lastSignedInAt
+          ? _self.lastSignedInAt
+          : lastSignedInAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _Device implements Device {
+  const _Device(
+      {required this.id,
+      required this.deviceID,
+      required this.name,
+      required this.type,
+      required this.userID,
+      required this.createdAt,
+      required this.lastSignedInAt});
+  factory _Device.fromJson(Map<String, dynamic> json) => _$DeviceFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String deviceID;
+  @override
+  final String name;
+  @override
+  final DeviceType type;
+  @override
+  final String userID;
+  @override
+  final DateTime createdAt;
+  @override
+  final DateTime lastSignedInAt;
+
+  /// Create a copy of Device
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$DeviceCopyWith<_Device> get copyWith =>
+      __$DeviceCopyWithImpl<_Device>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$DeviceToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Device &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.deviceID, deviceID) ||
+                other.deviceID == deviceID) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.userID, userID) || other.userID == userID) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.lastSignedInAt, lastSignedInAt) ||
+                other.lastSignedInAt == lastSignedInAt));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, id, deviceID, name, type, userID, createdAt, lastSignedInAt);
+
+  @override
+  String toString() {
+    return 'Device(id: $id, deviceID: $deviceID, name: $name, type: $type, userID: $userID, createdAt: $createdAt, lastSignedInAt: $lastSignedInAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$DeviceCopyWith<$Res> implements $DeviceCopyWith<$Res> {
+  factory _$DeviceCopyWith(_Device value, $Res Function(_Device) _then) =
+      __$DeviceCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String deviceID,
+      String name,
+      DeviceType type,
+      String userID,
+      DateTime createdAt,
+      DateTime lastSignedInAt});
+}
+
+/// @nodoc
+class __$DeviceCopyWithImpl<$Res> implements _$DeviceCopyWith<$Res> {
+  __$DeviceCopyWithImpl(this._self, this._then);
+
+  final _Device _self;
+  final $Res Function(_Device) _then;
+
+  /// Create a copy of Device
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? deviceID = null,
+    Object? name = null,
+    Object? type = null,
+    Object? userID = null,
+    Object? createdAt = null,
+    Object? lastSignedInAt = null,
+  }) {
+    return _then(_Device(
       id: null == id
           ? _self.id
           : id // ignore: cast_nullable_to_non_nullable

--- a/lib/src/models/device.g.dart
+++ b/lib/src/models/device.g.dart
@@ -6,7 +6,7 @@ part of 'device.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-Device _$DeviceFromJson(Map<String, dynamic> json) => Device(
+_Device _$DeviceFromJson(Map<String, dynamic> json) => _Device(
       id: json['id'] as String,
       deviceID: json['deviceID'] as String,
       name: json['name'] as String,
@@ -16,7 +16,7 @@ Device _$DeviceFromJson(Map<String, dynamic> json) => Device(
       lastSignedInAt: DateTime.parse(json['lastSignedInAt'] as String),
     );
 
-Map<String, dynamic> _$DeviceToJson(Device instance) => <String, dynamic>{
+Map<String, dynamic> _$DeviceToJson(_Device instance) => <String, dynamic>{
       'id': instance.id,
       'deviceID': instance.deviceID,
       'name': instance.name,

--- a/lib/src/models/factor.dart
+++ b/lib/src/models/factor.dart
@@ -11,34 +11,21 @@ part 'factor.g.dart';
 /// An Identity object contains information about a specific authentication
 /// method used by a user, including the provider, user IDs, and timestamps.
 @freezed
-@JsonSerializable()
-class Factor with _$Factor {
+abstract class Factor with _$Factor {
   /// Creates a new instance of [Factor] with the specified parameters.
-  const Factor({
-    required this.id,
-    required this.providerUserID,
-    required this.userID,
-    required this.factor,
-    required this.identifier,
-    required this.data,
-    required this.createdAt,
-    required this.lastSignedInAt,
-  });
+  const factory Factor({
+    required String id,
+    required String providerUserID,
+    required String userID,
+    required FactorType factor,
+    required String identifier,
+    required FactorData data,
+    required DateTime createdAt,
+    required DateTime lastSignedInAt,
+  }) = _Factor;
 
   /// Used to serialize [Factor] object from JSON.
   factory Factor.fromJson(Map<String, Object?> json) => _$FactorFromJson(json);
-
-  /// Used to serialize [Factor] object to JSON.
-  Map<String, Object?> toJson() => _$FactorToJson(this);
-
-  final String id;
-  final String providerUserID;
-  final String userID;
-  final FactorType factor;
-  final String identifier;
-  final FactorData data;
-  final DateTime createdAt;
-  final DateTime lastSignedInAt;
 }
 
 /// Represents the various identity providers and authentication methods

--- a/lib/src/models/factor.freezed.dart
+++ b/lib/src/models/factor.freezed.dart
@@ -31,6 +31,9 @@ mixin _$Factor {
   $FactorCopyWith<Factor> get copyWith =>
       _$FactorCopyWithImpl<Factor>(this as Factor, _$identity);
 
+  /// Serializes this Factor to a JSON map.
+  Map<String, dynamic> toJson();
+
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
@@ -75,6 +78,8 @@ abstract mixin class $FactorCopyWith<$Res> {
       FactorData data,
       DateTime createdAt,
       DateTime lastSignedInAt});
+
+  $FactorDataCopyWith<$Res> get data;
 }
 
 /// @nodoc
@@ -98,7 +103,7 @@ class _$FactorCopyWithImpl<$Res> implements $FactorCopyWith<$Res> {
     Object? createdAt = null,
     Object? lastSignedInAt = null,
   }) {
-    return _then(Factor(
+    return _then(_self.copyWith(
       id: null == id
           ? _self.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -132,6 +137,180 @@ class _$FactorCopyWithImpl<$Res> implements $FactorCopyWith<$Res> {
           : lastSignedInAt // ignore: cast_nullable_to_non_nullable
               as DateTime,
     ));
+  }
+
+  /// Create a copy of Factor
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $FactorDataCopyWith<$Res> get data {
+    return $FactorDataCopyWith<$Res>(_self.data, (value) {
+      return _then(_self.copyWith(data: value));
+    });
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _Factor implements Factor {
+  const _Factor(
+      {required this.id,
+      required this.providerUserID,
+      required this.userID,
+      required this.factor,
+      required this.identifier,
+      required this.data,
+      required this.createdAt,
+      required this.lastSignedInAt});
+  factory _Factor.fromJson(Map<String, dynamic> json) => _$FactorFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String providerUserID;
+  @override
+  final String userID;
+  @override
+  final FactorType factor;
+  @override
+  final String identifier;
+  @override
+  final FactorData data;
+  @override
+  final DateTime createdAt;
+  @override
+  final DateTime lastSignedInAt;
+
+  /// Create a copy of Factor
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$FactorCopyWith<_Factor> get copyWith =>
+      __$FactorCopyWithImpl<_Factor>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$FactorToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Factor &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.providerUserID, providerUserID) ||
+                other.providerUserID == providerUserID) &&
+            (identical(other.userID, userID) || other.userID == userID) &&
+            (identical(other.factor, factor) || other.factor == factor) &&
+            (identical(other.identifier, identifier) ||
+                other.identifier == identifier) &&
+            (identical(other.data, data) || other.data == data) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.lastSignedInAt, lastSignedInAt) ||
+                other.lastSignedInAt == lastSignedInAt));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, providerUserID, userID,
+      factor, identifier, data, createdAt, lastSignedInAt);
+
+  @override
+  String toString() {
+    return 'Factor(id: $id, providerUserID: $providerUserID, userID: $userID, factor: $factor, identifier: $identifier, data: $data, createdAt: $createdAt, lastSignedInAt: $lastSignedInAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$FactorCopyWith<$Res> implements $FactorCopyWith<$Res> {
+  factory _$FactorCopyWith(_Factor value, $Res Function(_Factor) _then) =
+      __$FactorCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String providerUserID,
+      String userID,
+      FactorType factor,
+      String identifier,
+      FactorData data,
+      DateTime createdAt,
+      DateTime lastSignedInAt});
+
+  @override
+  $FactorDataCopyWith<$Res> get data;
+}
+
+/// @nodoc
+class __$FactorCopyWithImpl<$Res> implements _$FactorCopyWith<$Res> {
+  __$FactorCopyWithImpl(this._self, this._then);
+
+  final _Factor _self;
+  final $Res Function(_Factor) _then;
+
+  /// Create a copy of Factor
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? providerUserID = null,
+    Object? userID = null,
+    Object? factor = null,
+    Object? identifier = null,
+    Object? data = null,
+    Object? createdAt = null,
+    Object? lastSignedInAt = null,
+  }) {
+    return _then(_Factor(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      providerUserID: null == providerUserID
+          ? _self.providerUserID
+          : providerUserID // ignore: cast_nullable_to_non_nullable
+              as String,
+      userID: null == userID
+          ? _self.userID
+          : userID // ignore: cast_nullable_to_non_nullable
+              as String,
+      factor: null == factor
+          ? _self.factor
+          : factor // ignore: cast_nullable_to_non_nullable
+              as FactorType,
+      identifier: null == identifier
+          ? _self.identifier
+          : identifier // ignore: cast_nullable_to_non_nullable
+              as String,
+      data: null == data
+          ? _self.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as FactorData,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      lastSignedInAt: null == lastSignedInAt
+          ? _self.lastSignedInAt
+          : lastSignedInAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
+
+  /// Create a copy of Factor
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $FactorDataCopyWith<$Res> get data {
+    return $FactorDataCopyWith<$Res>(_self.data, (value) {
+      return _then(_self.copyWith(data: value));
+    });
   }
 }
 

--- a/lib/src/models/factor.g.dart
+++ b/lib/src/models/factor.g.dart
@@ -6,7 +6,7 @@ part of 'factor.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-Factor _$FactorFromJson(Map<String, dynamic> json) => Factor(
+_Factor _$FactorFromJson(Map<String, dynamic> json) => _Factor(
       id: json['id'] as String,
       providerUserID: json['providerUserID'] as String,
       userID: json['userID'] as String,
@@ -17,7 +17,7 @@ Factor _$FactorFromJson(Map<String, dynamic> json) => Factor(
       lastSignedInAt: DateTime.parse(json['lastSignedInAt'] as String),
     );
 
-Map<String, dynamic> _$FactorToJson(Factor instance) => <String, dynamic>{
+Map<String, dynamic> _$FactorToJson(_Factor instance) => <String, dynamic>{
       'id': instance.id,
       'providerUserID': instance.providerUserID,
       'userID': instance.userID,

--- a/lib/src/models/session.dart
+++ b/lib/src/models/session.dart
@@ -13,44 +13,28 @@ part 'session.g.dart';
 /// for the session, identity, device, and user, as well as the authentication
 /// token and expiration time.
 @freezed
-@JsonSerializable()
-class Session with _$Session {
+abstract class Session with _$Session {
   /// Creates a new Session instance.
-  const Session({
-    required this.id,
-    required this.appID,
-    required this.userID,
-    required this.deviceID,
-    required this.factorID,
-    required this.status,
-    required this.token,
-    required this.ipAddress,
-    required this.city,
-    required this.state,
-    required this.country,
-    required this.expiresAt,
-    required this.createdAt,
-    required this.updatedAt,
-  });
+  const factory Session({
+    required String id,
+    required String appID,
+    required String userID,
+    required String deviceID,
+    required String factorID,
+    required SessionStatus status,
+    required String token,
+    required String? ipAddress,
+    required String? city,
+    required String? state,
+    required String? country,
+    required DateTime? expiresAt,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+  }) = _Session;
 
   /// Used to serialize [Session] object to and from JSON.
   factory Session.fromJson(Map<String, Object?> json) =>
       _$SessionFromJson(json);
-
-  final String id;
-  final String appID;
-  final String userID;
-  final String deviceID;
-  final String factorID;
-  final SessionStatus status;
-  final String token;
-  final String? ipAddress;
-  final String? city;
-  final String? state;
-  final String? country;
-  final DateTime? expiresAt;
-  final DateTime createdAt;
-  final DateTime updatedAt;
 }
 
 /// Represents the status of a user's session.
@@ -71,32 +55,29 @@ enum SessionStatus {
 /// Extends the Session class by including the full Auth object associated
 /// with the user, providing more comprehensive session data.
 @freezed
-@JsonSerializable()
-class UserSession extends Session with _$UserSession {
+abstract class UserSession with _$UserSession {
   /// Creates a new AuthSession instance.
-  const UserSession({
-    required super.id,
-    required super.appID,
-    required super.userID,
-    required super.deviceID,
-    required super.factorID,
-    required super.status,
-    required super.token,
-    required super.ipAddress,
-    required super.city,
-    required super.state,
-    required super.country,
-    required super.expiresAt,
-    required super.createdAt,
-    required super.updatedAt,
-    required this.user,
-  });
+  const factory UserSession({
+    required String id,
+    required String appID,
+    required String userID,
+    required String deviceID,
+    required String factorID,
+    required SessionStatus status,
+    required String token,
+    required String? ipAddress,
+    required String? city,
+    required String? state,
+    required String? country,
+    required DateTime? expiresAt,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    required User user,
+  }) = _UserSession;
 
   /// Used to serialize [UserSession] object to and from JSON.
   factory UserSession.fromJson(Map<String, Object?> json) =>
       _$UserSessionFromJson(json);
-
-  final User user;
 }
 
 /// Represents a user's session in the Drift database.

--- a/lib/src/models/session.freezed.dart
+++ b/lib/src/models/session.freezed.dart
@@ -37,6 +37,9 @@ mixin _$Session {
   $SessionCopyWith<Session> get copyWith =>
       _$SessionCopyWithImpl<Session>(this as Session, _$identity);
 
+  /// Serializes this Session to a JSON map.
+  Map<String, dynamic> toJson();
+
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
@@ -138,7 +141,235 @@ class _$SessionCopyWithImpl<$Res> implements $SessionCopyWith<$Res> {
     Object? createdAt = null,
     Object? updatedAt = null,
   }) {
-    return _then(Session(
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      appID: null == appID
+          ? _self.appID
+          : appID // ignore: cast_nullable_to_non_nullable
+              as String,
+      userID: null == userID
+          ? _self.userID
+          : userID // ignore: cast_nullable_to_non_nullable
+              as String,
+      deviceID: null == deviceID
+          ? _self.deviceID
+          : deviceID // ignore: cast_nullable_to_non_nullable
+              as String,
+      factorID: null == factorID
+          ? _self.factorID
+          : factorID // ignore: cast_nullable_to_non_nullable
+              as String,
+      status: null == status
+          ? _self.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as SessionStatus,
+      token: null == token
+          ? _self.token
+          : token // ignore: cast_nullable_to_non_nullable
+              as String,
+      ipAddress: freezed == ipAddress
+          ? _self.ipAddress
+          : ipAddress // ignore: cast_nullable_to_non_nullable
+              as String?,
+      city: freezed == city
+          ? _self.city
+          : city // ignore: cast_nullable_to_non_nullable
+              as String?,
+      state: freezed == state
+          ? _self.state
+          : state // ignore: cast_nullable_to_non_nullable
+              as String?,
+      country: freezed == country
+          ? _self.country
+          : country // ignore: cast_nullable_to_non_nullable
+              as String?,
+      expiresAt: freezed == expiresAt
+          ? _self.expiresAt
+          : expiresAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _Session implements Session {
+  const _Session(
+      {required this.id,
+      required this.appID,
+      required this.userID,
+      required this.deviceID,
+      required this.factorID,
+      required this.status,
+      required this.token,
+      required this.ipAddress,
+      required this.city,
+      required this.state,
+      required this.country,
+      required this.expiresAt,
+      required this.createdAt,
+      required this.updatedAt});
+  factory _Session.fromJson(Map<String, dynamic> json) =>
+      _$SessionFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String appID;
+  @override
+  final String userID;
+  @override
+  final String deviceID;
+  @override
+  final String factorID;
+  @override
+  final SessionStatus status;
+  @override
+  final String token;
+  @override
+  final String? ipAddress;
+  @override
+  final String? city;
+  @override
+  final String? state;
+  @override
+  final String? country;
+  @override
+  final DateTime? expiresAt;
+  @override
+  final DateTime createdAt;
+  @override
+  final DateTime updatedAt;
+
+  /// Create a copy of Session
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$SessionCopyWith<_Session> get copyWith =>
+      __$SessionCopyWithImpl<_Session>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$SessionToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Session &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.appID, appID) || other.appID == appID) &&
+            (identical(other.userID, userID) || other.userID == userID) &&
+            (identical(other.deviceID, deviceID) ||
+                other.deviceID == deviceID) &&
+            (identical(other.factorID, factorID) ||
+                other.factorID == factorID) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.token, token) || other.token == token) &&
+            (identical(other.ipAddress, ipAddress) ||
+                other.ipAddress == ipAddress) &&
+            (identical(other.city, city) || other.city == city) &&
+            (identical(other.state, state) || other.state == state) &&
+            (identical(other.country, country) || other.country == country) &&
+            (identical(other.expiresAt, expiresAt) ||
+                other.expiresAt == expiresAt) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      appID,
+      userID,
+      deviceID,
+      factorID,
+      status,
+      token,
+      ipAddress,
+      city,
+      state,
+      country,
+      expiresAt,
+      createdAt,
+      updatedAt);
+
+  @override
+  String toString() {
+    return 'Session(id: $id, appID: $appID, userID: $userID, deviceID: $deviceID, factorID: $factorID, status: $status, token: $token, ipAddress: $ipAddress, city: $city, state: $state, country: $country, expiresAt: $expiresAt, createdAt: $createdAt, updatedAt: $updatedAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$SessionCopyWith<$Res> implements $SessionCopyWith<$Res> {
+  factory _$SessionCopyWith(_Session value, $Res Function(_Session) _then) =
+      __$SessionCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String appID,
+      String userID,
+      String deviceID,
+      String factorID,
+      SessionStatus status,
+      String token,
+      String? ipAddress,
+      String? city,
+      String? state,
+      String? country,
+      DateTime? expiresAt,
+      DateTime createdAt,
+      DateTime updatedAt});
+}
+
+/// @nodoc
+class __$SessionCopyWithImpl<$Res> implements _$SessionCopyWith<$Res> {
+  __$SessionCopyWithImpl(this._self, this._then);
+
+  final _Session _self;
+  final $Res Function(_Session) _then;
+
+  /// Create a copy of Session
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? appID = null,
+    Object? userID = null,
+    Object? deviceID = null,
+    Object? factorID = null,
+    Object? status = null,
+    Object? token = null,
+    Object? ipAddress = freezed,
+    Object? city = freezed,
+    Object? state = freezed,
+    Object? country = freezed,
+    Object? expiresAt = freezed,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+  }) {
+    return _then(_Session(
       id: null == id
           ? _self.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -201,6 +432,20 @@ class _$SessionCopyWithImpl<$Res> implements $SessionCopyWith<$Res> {
 
 /// @nodoc
 mixin _$UserSession {
+  String get id;
+  String get appID;
+  String get userID;
+  String get deviceID;
+  String get factorID;
+  SessionStatus get status;
+  String get token;
+  String? get ipAddress;
+  String? get city;
+  String? get state;
+  String? get country;
+  DateTime? get expiresAt;
+  DateTime get createdAt;
+  DateTime get updatedAt;
   User get user;
 
   /// Create a copy of UserSession
@@ -210,27 +455,65 @@ mixin _$UserSession {
   $UserSessionCopyWith<UserSession> get copyWith =>
       _$UserSessionCopyWithImpl<UserSession>(this as UserSession, _$identity);
 
+  /// Serializes this UserSession to a JSON map.
+  Map<String, dynamic> toJson();
+
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is UserSession &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.appID, appID) || other.appID == appID) &&
+            (identical(other.userID, userID) || other.userID == userID) &&
+            (identical(other.deviceID, deviceID) ||
+                other.deviceID == deviceID) &&
+            (identical(other.factorID, factorID) ||
+                other.factorID == factorID) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.token, token) || other.token == token) &&
+            (identical(other.ipAddress, ipAddress) ||
+                other.ipAddress == ipAddress) &&
+            (identical(other.city, city) || other.city == city) &&
+            (identical(other.state, state) || other.state == state) &&
+            (identical(other.country, country) || other.country == country) &&
+            (identical(other.expiresAt, expiresAt) ||
+                other.expiresAt == expiresAt) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt) &&
             (identical(other.user, user) || other.user == user));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(runtimeType, user);
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      appID,
+      userID,
+      deviceID,
+      factorID,
+      status,
+      token,
+      ipAddress,
+      city,
+      state,
+      country,
+      expiresAt,
+      createdAt,
+      updatedAt,
+      user);
 
   @override
   String toString() {
-    return 'UserSession(user: $user)';
+    return 'UserSession(id: $id, appID: $appID, userID: $userID, deviceID: $deviceID, factorID: $factorID, status: $status, token: $token, ipAddress: $ipAddress, city: $city, state: $state, country: $country, expiresAt: $expiresAt, createdAt: $createdAt, updatedAt: $updatedAt, user: $user)';
   }
 }
 
 /// @nodoc
-abstract mixin class $UserSessionCopyWith<$Res>
-    implements $SessionCopyWith<$Res> {
+abstract mixin class $UserSessionCopyWith<$Res> {
   factory $UserSessionCopyWith(
           UserSession value, $Res Function(UserSession) _then) =
       _$UserSessionCopyWithImpl;
@@ -251,6 +534,8 @@ abstract mixin class $UserSessionCopyWith<$Res>
       DateTime createdAt,
       DateTime updatedAt,
       User user});
+
+  $UserCopyWith<$Res> get user;
 }
 
 /// @nodoc
@@ -281,7 +566,7 @@ class _$UserSessionCopyWithImpl<$Res> implements $UserSessionCopyWith<$Res> {
     Object? updatedAt = null,
     Object? user = null,
   }) {
-    return _then(UserSession(
+    return _then(_self.copyWith(
       id: null == id
           ? _self.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -343,6 +628,270 @@ class _$UserSessionCopyWithImpl<$Res> implements $UserSessionCopyWith<$Res> {
           : user // ignore: cast_nullable_to_non_nullable
               as User,
     ));
+  }
+
+  /// Create a copy of UserSession
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $UserCopyWith<$Res> get user {
+    return $UserCopyWith<$Res>(_self.user, (value) {
+      return _then(_self.copyWith(user: value));
+    });
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _UserSession implements UserSession {
+  const _UserSession(
+      {required this.id,
+      required this.appID,
+      required this.userID,
+      required this.deviceID,
+      required this.factorID,
+      required this.status,
+      required this.token,
+      required this.ipAddress,
+      required this.city,
+      required this.state,
+      required this.country,
+      required this.expiresAt,
+      required this.createdAt,
+      required this.updatedAt,
+      required this.user});
+  factory _UserSession.fromJson(Map<String, dynamic> json) =>
+      _$UserSessionFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String appID;
+  @override
+  final String userID;
+  @override
+  final String deviceID;
+  @override
+  final String factorID;
+  @override
+  final SessionStatus status;
+  @override
+  final String token;
+  @override
+  final String? ipAddress;
+  @override
+  final String? city;
+  @override
+  final String? state;
+  @override
+  final String? country;
+  @override
+  final DateTime? expiresAt;
+  @override
+  final DateTime createdAt;
+  @override
+  final DateTime updatedAt;
+  @override
+  final User user;
+
+  /// Create a copy of UserSession
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$UserSessionCopyWith<_UserSession> get copyWith =>
+      __$UserSessionCopyWithImpl<_UserSession>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$UserSessionToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _UserSession &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.appID, appID) || other.appID == appID) &&
+            (identical(other.userID, userID) || other.userID == userID) &&
+            (identical(other.deviceID, deviceID) ||
+                other.deviceID == deviceID) &&
+            (identical(other.factorID, factorID) ||
+                other.factorID == factorID) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.token, token) || other.token == token) &&
+            (identical(other.ipAddress, ipAddress) ||
+                other.ipAddress == ipAddress) &&
+            (identical(other.city, city) || other.city == city) &&
+            (identical(other.state, state) || other.state == state) &&
+            (identical(other.country, country) || other.country == country) &&
+            (identical(other.expiresAt, expiresAt) ||
+                other.expiresAt == expiresAt) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt) &&
+            (identical(other.user, user) || other.user == user));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      appID,
+      userID,
+      deviceID,
+      factorID,
+      status,
+      token,
+      ipAddress,
+      city,
+      state,
+      country,
+      expiresAt,
+      createdAt,
+      updatedAt,
+      user);
+
+  @override
+  String toString() {
+    return 'UserSession(id: $id, appID: $appID, userID: $userID, deviceID: $deviceID, factorID: $factorID, status: $status, token: $token, ipAddress: $ipAddress, city: $city, state: $state, country: $country, expiresAt: $expiresAt, createdAt: $createdAt, updatedAt: $updatedAt, user: $user)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$UserSessionCopyWith<$Res>
+    implements $UserSessionCopyWith<$Res> {
+  factory _$UserSessionCopyWith(
+          _UserSession value, $Res Function(_UserSession) _then) =
+      __$UserSessionCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String appID,
+      String userID,
+      String deviceID,
+      String factorID,
+      SessionStatus status,
+      String token,
+      String? ipAddress,
+      String? city,
+      String? state,
+      String? country,
+      DateTime? expiresAt,
+      DateTime createdAt,
+      DateTime updatedAt,
+      User user});
+
+  @override
+  $UserCopyWith<$Res> get user;
+}
+
+/// @nodoc
+class __$UserSessionCopyWithImpl<$Res> implements _$UserSessionCopyWith<$Res> {
+  __$UserSessionCopyWithImpl(this._self, this._then);
+
+  final _UserSession _self;
+  final $Res Function(_UserSession) _then;
+
+  /// Create a copy of UserSession
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? appID = null,
+    Object? userID = null,
+    Object? deviceID = null,
+    Object? factorID = null,
+    Object? status = null,
+    Object? token = null,
+    Object? ipAddress = freezed,
+    Object? city = freezed,
+    Object? state = freezed,
+    Object? country = freezed,
+    Object? expiresAt = freezed,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+    Object? user = null,
+  }) {
+    return _then(_UserSession(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      appID: null == appID
+          ? _self.appID
+          : appID // ignore: cast_nullable_to_non_nullable
+              as String,
+      userID: null == userID
+          ? _self.userID
+          : userID // ignore: cast_nullable_to_non_nullable
+              as String,
+      deviceID: null == deviceID
+          ? _self.deviceID
+          : deviceID // ignore: cast_nullable_to_non_nullable
+              as String,
+      factorID: null == factorID
+          ? _self.factorID
+          : factorID // ignore: cast_nullable_to_non_nullable
+              as String,
+      status: null == status
+          ? _self.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as SessionStatus,
+      token: null == token
+          ? _self.token
+          : token // ignore: cast_nullable_to_non_nullable
+              as String,
+      ipAddress: freezed == ipAddress
+          ? _self.ipAddress
+          : ipAddress // ignore: cast_nullable_to_non_nullable
+              as String?,
+      city: freezed == city
+          ? _self.city
+          : city // ignore: cast_nullable_to_non_nullable
+              as String?,
+      state: freezed == state
+          ? _self.state
+          : state // ignore: cast_nullable_to_non_nullable
+              as String?,
+      country: freezed == country
+          ? _self.country
+          : country // ignore: cast_nullable_to_non_nullable
+              as String?,
+      expiresAt: freezed == expiresAt
+          ? _self.expiresAt
+          : expiresAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      user: null == user
+          ? _self.user
+          : user // ignore: cast_nullable_to_non_nullable
+              as User,
+    ));
+  }
+
+  /// Create a copy of UserSession
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $UserCopyWith<$Res> get user {
+    return $UserCopyWith<$Res>(_self.user, (value) {
+      return _then(_self.copyWith(user: value));
+    });
   }
 }
 

--- a/lib/src/models/session.g.dart
+++ b/lib/src/models/session.g.dart
@@ -6,7 +6,7 @@ part of 'session.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-Session _$SessionFromJson(Map<String, dynamic> json) => Session(
+_Session _$SessionFromJson(Map<String, dynamic> json) => _Session(
       id: json['id'] as String,
       appID: json['appID'] as String,
       userID: json['userID'] as String,
@@ -25,7 +25,7 @@ Session _$SessionFromJson(Map<String, dynamic> json) => Session(
       updatedAt: DateTime.parse(json['updatedAt'] as String),
     );
 
-Map<String, dynamic> _$SessionToJson(Session instance) => <String, dynamic>{
+Map<String, dynamic> _$SessionToJson(_Session instance) => <String, dynamic>{
       'id': instance.id,
       'appID': instance.appID,
       'userID': instance.userID,
@@ -48,7 +48,7 @@ const _$SessionStatusEnumMap = {
   SessionStatus.active: 'active',
 };
 
-UserSession _$UserSessionFromJson(Map<String, dynamic> json) => UserSession(
+_UserSession _$UserSessionFromJson(Map<String, dynamic> json) => _UserSession(
       id: json['id'] as String,
       appID: json['appID'] as String,
       userID: json['userID'] as String,
@@ -68,7 +68,7 @@ UserSession _$UserSessionFromJson(Map<String, dynamic> json) => UserSession(
       user: User.fromJson(json['user'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$UserSessionToJson(UserSession instance) =>
+Map<String, dynamic> _$UserSessionToJson(_UserSession instance) =>
     <String, dynamic>{
       'id': instance.id,
       'appID': instance.appID,

--- a/lib/src/models/user.dart
+++ b/lib/src/models/user.dart
@@ -14,39 +14,27 @@ part 'user.g.dart';
 /// identities and devices, and optional personal information such as
 /// name, email, phone, and profile image.
 @freezed
-@JsonSerializable()
-class User with _$User {
+abstract class User with _$User {
   /// Creates a new instance of [User] with the specified parameters.
-  const User({
-    required this.id,
-    required this.firstName,
-    required this.lastName,
-    required this.email,
-    required this.phoneNumber,
-    required this.image,
-    required this.twoFactor,
-    required this.banned,
-    required this.createdAt,
-    required this.updatedAt,
-    required this.factors,
-    required this.devices,
-  });
+  const factory User({
+    required String id,
+    required String? firstName,
+    required String? lastName,
+    required String? email,
+    required String? phoneNumber,
+    required String? image,
+    required bool twoFactor,
+    required bool banned,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    required List<Factor> factors,
+    required List<Device> devices,
+  }) = _User;
 
   /// Used to serialize [User] object to and from JSON.
   factory User.fromJson(Map<String, Object?> json) => _$UserFromJson(json);
 
-  final String id;
-  final String? firstName;
-  final String? lastName;
-  final String? email;
-  final String? phoneNumber;
-  final String? image;
-  final bool twoFactor;
-  final bool banned;
-  final DateTime createdAt;
-  final DateTime updatedAt;
-  final List<Factor> factors;
-  final List<Device> devices;
+  const User._();
 
   /// Returns true if the user has a first name, false otherwise.
   bool get isRegistered => firstName != null;

--- a/lib/src/models/user.freezed.dart
+++ b/lib/src/models/user.freezed.dart
@@ -35,6 +35,9 @@ mixin _$User {
   $UserCopyWith<User> get copyWith =>
       _$UserCopyWithImpl<User>(this as User, _$identity);
 
+  /// Serializes this User to a JSON map.
+  Map<String, dynamic> toJson();
+
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
@@ -128,7 +131,7 @@ class _$UserCopyWithImpl<$Res> implements $UserCopyWith<$Res> {
     Object? factors = null,
     Object? devices = null,
   }) {
-    return _then(User(
+    return _then(_self.copyWith(
       id: null == id
           ? _self.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -175,6 +178,225 @@ class _$UserCopyWithImpl<$Res> implements $UserCopyWith<$Res> {
               as List<Factor>,
       devices: null == devices
           ? _self.devices
+          : devices // ignore: cast_nullable_to_non_nullable
+              as List<Device>,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _User extends User {
+  const _User(
+      {required this.id,
+      required this.firstName,
+      required this.lastName,
+      required this.email,
+      required this.phoneNumber,
+      required this.image,
+      required this.twoFactor,
+      required this.banned,
+      required this.createdAt,
+      required this.updatedAt,
+      required final List<Factor> factors,
+      required final List<Device> devices})
+      : _factors = factors,
+        _devices = devices,
+        super._();
+  factory _User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String? firstName;
+  @override
+  final String? lastName;
+  @override
+  final String? email;
+  @override
+  final String? phoneNumber;
+  @override
+  final String? image;
+  @override
+  final bool twoFactor;
+  @override
+  final bool banned;
+  @override
+  final DateTime createdAt;
+  @override
+  final DateTime updatedAt;
+  final List<Factor> _factors;
+  @override
+  List<Factor> get factors {
+    if (_factors is EqualUnmodifiableListView) return _factors;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_factors);
+  }
+
+  final List<Device> _devices;
+  @override
+  List<Device> get devices {
+    if (_devices is EqualUnmodifiableListView) return _devices;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_devices);
+  }
+
+  /// Create a copy of User
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$UserCopyWith<_User> get copyWith =>
+      __$UserCopyWithImpl<_User>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$UserToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _User &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.firstName, firstName) ||
+                other.firstName == firstName) &&
+            (identical(other.lastName, lastName) ||
+                other.lastName == lastName) &&
+            (identical(other.email, email) || other.email == email) &&
+            (identical(other.phoneNumber, phoneNumber) ||
+                other.phoneNumber == phoneNumber) &&
+            (identical(other.image, image) || other.image == image) &&
+            (identical(other.twoFactor, twoFactor) ||
+                other.twoFactor == twoFactor) &&
+            (identical(other.banned, banned) || other.banned == banned) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt) &&
+            const DeepCollectionEquality().equals(other._factors, _factors) &&
+            const DeepCollectionEquality().equals(other._devices, _devices));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      firstName,
+      lastName,
+      email,
+      phoneNumber,
+      image,
+      twoFactor,
+      banned,
+      createdAt,
+      updatedAt,
+      const DeepCollectionEquality().hash(_factors),
+      const DeepCollectionEquality().hash(_devices));
+
+  @override
+  String toString() {
+    return 'User(id: $id, firstName: $firstName, lastName: $lastName, email: $email, phoneNumber: $phoneNumber, image: $image, twoFactor: $twoFactor, banned: $banned, createdAt: $createdAt, updatedAt: $updatedAt, factors: $factors, devices: $devices)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$UserCopyWith<$Res> implements $UserCopyWith<$Res> {
+  factory _$UserCopyWith(_User value, $Res Function(_User) _then) =
+      __$UserCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String? firstName,
+      String? lastName,
+      String? email,
+      String? phoneNumber,
+      String? image,
+      bool twoFactor,
+      bool banned,
+      DateTime createdAt,
+      DateTime updatedAt,
+      List<Factor> factors,
+      List<Device> devices});
+}
+
+/// @nodoc
+class __$UserCopyWithImpl<$Res> implements _$UserCopyWith<$Res> {
+  __$UserCopyWithImpl(this._self, this._then);
+
+  final _User _self;
+  final $Res Function(_User) _then;
+
+  /// Create a copy of User
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? firstName = freezed,
+    Object? lastName = freezed,
+    Object? email = freezed,
+    Object? phoneNumber = freezed,
+    Object? image = freezed,
+    Object? twoFactor = null,
+    Object? banned = null,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+    Object? factors = null,
+    Object? devices = null,
+  }) {
+    return _then(_User(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      firstName: freezed == firstName
+          ? _self.firstName
+          : firstName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      lastName: freezed == lastName
+          ? _self.lastName
+          : lastName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      email: freezed == email
+          ? _self.email
+          : email // ignore: cast_nullable_to_non_nullable
+              as String?,
+      phoneNumber: freezed == phoneNumber
+          ? _self.phoneNumber
+          : phoneNumber // ignore: cast_nullable_to_non_nullable
+              as String?,
+      image: freezed == image
+          ? _self.image
+          : image // ignore: cast_nullable_to_non_nullable
+              as String?,
+      twoFactor: null == twoFactor
+          ? _self.twoFactor
+          : twoFactor // ignore: cast_nullable_to_non_nullable
+              as bool,
+      banned: null == banned
+          ? _self.banned
+          : banned // ignore: cast_nullable_to_non_nullable
+              as bool,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      factors: null == factors
+          ? _self._factors
+          : factors // ignore: cast_nullable_to_non_nullable
+              as List<Factor>,
+      devices: null == devices
+          ? _self._devices
           : devices // ignore: cast_nullable_to_non_nullable
               as List<Device>,
     ));

--- a/lib/src/models/user.g.dart
+++ b/lib/src/models/user.g.dart
@@ -6,7 +6,7 @@ part of 'user.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-User _$UserFromJson(Map<String, dynamic> json) => User(
+_User _$UserFromJson(Map<String, dynamic> json) => _User(
       id: json['id'] as String,
       firstName: json['firstName'] as String?,
       lastName: json['lastName'] as String?,
@@ -25,7 +25,7 @@ User _$UserFromJson(Map<String, dynamic> json) => User(
           .toList(),
     );
 
-Map<String, dynamic> _$UserToJson(User instance) => <String, dynamic>{
+Map<String, dynamic> _$UserToJson(_User instance) => <String, dynamic>{
       'id': instance.id,
       'firstName': instance.firstName,
       'lastName': instance.lastName,


### PR DESCRIPTION
This pull request includes significant refactoring of the `Device`, `Factor`, and `Session` models in the project. The changes primarily involve converting these classes to use the factory pattern and making adjustments to their serialization methods.

Refactoring of models:

* [`lib/src/models/device.dart`](diffhunk://#diff-4dd11f5ae837ee9ed9c0f782fef66bad5c6bc61dd0d9e1c93b66e33acc9536ccL36-L61): Changed `Device` class to an abstract class with a factory constructor and moved field definitions to the factory constructor.
* [`lib/src/models/device.freezed.dart`](diffhunk://#diff-b8eac6250e6ed9192343b87d8fdf61cf221f064f1c2c8d6038fc59639215f94cR33-R35): Added `toJson` method to `_$Device` mixin and implemented `_Device` class with required fields and serialization methods. [[1]](diffhunk://#diff-b8eac6250e6ed9192343b87d8fdf61cf221f064f1c2c8d6038fc59639215f94cR33-R35) [[2]](diffhunk://#diff-b8eac6250e6ed9192343b87d8fdf61cf221f064f1c2c8d6038fc59639215f94cL96-R239)
* [`lib/src/models/device.g.dart`](diffhunk://#diff-85fb7841265cd6da5c22aeff0b31c8073f138f656c62a76260de1a7fcf20ce52L9-R9): Updated JSON serialization methods to use `_Device` instead of `Device`. [[1]](diffhunk://#diff-85fb7841265cd6da5c22aeff0b31c8073f138f656c62a76260de1a7fcf20ce52L9-R9) [[2]](diffhunk://#diff-85fb7841265cd6da5c22aeff0b31c8073f138f656c62a76260de1a7fcf20ce52L19-R19)

* [`lib/src/models/factor.dart`](diffhunk://#diff-b4b0dae419cdb077c860e39a8483df2a16dddc4aec1ad6b2186f338342958db1L14-L41): Changed `Factor` class to an abstract class with a factory constructor and moved field definitions to the factory constructor.
* [`lib/src/models/factor.freezed.dart`](diffhunk://#diff-28cda74ede0fccbbd74599ee2b9c1ceeb171533d98e2f20baabeb3550d530b9bR34-R36): Added `toJson` method to `_$Factor` mixin, implemented `_Factor` class with required fields and serialization methods, and updated `copyWith` method to handle nested `FactorData` objects. [[1]](diffhunk://#diff-28cda74ede0fccbbd74599ee2b9c1ceeb171533d98e2f20baabeb3550d530b9bR34-R36) [[2]](diffhunk://#diff-28cda74ede0fccbbd74599ee2b9c1ceeb171533d98e2f20baabeb3550d530b9bR81-R82) [[3]](diffhunk://#diff-28cda74ede0fccbbd74599ee2b9c1ceeb171533d98e2f20baabeb3550d530b9bL101-R270) [[4]](diffhunk://#diff-28cda74ede0fccbbd74599ee2b9c1ceeb171533d98e2f20baabeb3550d530b9bR305-R314)
* [`lib/src/models/factor.g.dart`](diffhunk://#diff-f5645af0d38d4165ed0c7c8544f55a7e7a43dd7a0d24a746659f8dc928f60a20L9-R9): Updated JSON serialization methods to use `_Factor` instead of `Factor`. [[1]](diffhunk://#diff-f5645af0d38d4165ed0c7c8544f55a7e7a43dd7a0d24a746659f8dc928f60a20L9-R9) [[2]](diffhunk://#diff-f5645af0d38d4165ed0c7c8544f55a7e7a43dd7a0d24a746659f8dc928f60a20L20-R20)

* [`lib/src/models/session.dart`](diffhunk://#diff-372a6b227846a1c15c84703fb97f670f3a79dd05dd08fab4309ca77e4019bb5aL16-L53): Changed `Session` and `UserSession` classes to abstract classes with factory constructors and moved field definitions to the factory constructors. [[1]](diffhunk://#diff-372a6b227846a1c15c84703fb97f670f3a79dd05dd08fab4309ca77e4019bb5aL16-L53) [[2]](diffhunk://#diff-372a6b227846a1c15c84703fb97f670f3a79dd05dd08fab4309ca77e4019bb5aL74-L99)
* [`lib/src/models/session.g.dart`](diffhunk://#diff-bacf7e964ea31200ee36bab39f66b58b3d1721f7e3f5f41180bbe7ead6b7be6bL9-R9): Updated JSON serialization methods to use `_Session` and `_UserSession` instead of `Session` and `UserSession`. [[1]](diffhunk://#diff-bacf7e964ea31200ee36bab39f66b58b3d1721f7e3f5f41180bbe7ead6b7be6bL9-R9) [[2]](diffhunk://#diff-bacf7e964ea31200ee36bab39f66b58b3d1721f7e3f5f41180bbe7ead6b7be6bL28-R28) [[3]](diffhunk://#diff-bacf7e964ea31200ee36bab39f66b58b3d1721f7e3f5f41180bbe7ead6b7be6bL51-R51) [[4]](diffhunk://#diff-bacf7e964ea31200ee36bab39f66b58b3d1721f7e3f5f41180bbe7ead6b7be6bL71-R71)